### PR TITLE
DateItem and DateTimeItem: added 'format' parameter for formatting

### DIFF
--- a/guidata/dataset/dataitems.py
+++ b/guidata/dataset/dataitems.py
@@ -312,10 +312,15 @@ class DateItem(DataItem):
         * text [string]: form's field name (optional)
         * label [string]: name
         * default [datetime.date]: default value (optional)
+        * format [string]: display format for date (optional)
         * help [string]: text shown in tooltip (optional)
     """
 
     type = datetime.date
+
+    def __init__(self, label, default=None, format=None, help="", check=True):
+        DataItem.__init__(self, label, default=default, help=help)
+        self.set_prop("display", format=format)
 
 
 class DateTimeItem(DateItem):

--- a/guidata/dataset/qtitemwidgets.py
+++ b/guidata/dataset/qtitemwidgets.py
@@ -420,6 +420,9 @@ class DateWidget(AbstractDataSetWidget):
         self.dateedit = self.group = QDateEdit()
         self.dateedit.setToolTip(item.get_help())
         self.dateedit.dateTimeChanged.connect(lambda value: self.notify_value_change())
+        fmt = self.item.get_prop("display", "format", None)
+        if fmt:
+            self.dateedit.setDisplayFormat(fmt)
 
     def get(self):
         """Override AbstractDataSetWidget method"""
@@ -451,6 +454,9 @@ class DateTimeWidget(AbstractDataSetWidget):
         self.dateedit.setCalendarPopup(True)
         self.dateedit.setToolTip(item.get_help())
         self.dateedit.dateTimeChanged.connect(lambda value: self.notify_value_change())
+        fmt = self.item.get_prop("display", "format", None)
+        if fmt:
+            self.dateedit.setDisplayFormat(fmt)
 
     def get(self):
         """Override AbstractDataSetWidget method"""


### PR DESCRIPTION
I found that DateTime widgets were displaying datetimes as "09/10/2022 07:59" on my system which meant that I couldn't see the seconds. I also prefer to use iso-formatted time when possible. This pull request adds the parameter 'format' to DateItem and DateTimeItem classes so that a custom format can be optionally provided. For instance:

`starttime = DateTimeItem("start",format="yyyy-MM-ddTHH:mm:ss")`

