### PR TITLE
Make the build reproducible

### DIFF
--- a/guidata/tests/test_loadsave_hdf5.py
+++ b/guidata/tests/test_loadsave_hdf5.py
@@ -38,6 +38,7 @@ def test_loadsave_hdf5():
             e.deserialize(reader)
             reader.close()
             e.edit()
+            os.unlink("test.h5")
         execenv.print("OK")
 
 

--- a/guidata/tests/test_loadsave_json.py
+++ b/guidata/tests/test_loadsave_json.py
@@ -36,6 +36,7 @@ def test_loadsave_json():
             reader = JSONReader("test.json")
             e.deserialize(reader)
             e.edit()
+            os.unlink("test.json")
         execenv.print("OK")
 
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort, I noticed that guidata could not be built reproducibly.

This is due to the testsuite not completely cleaning up after itself, so these files get installed into the guidata Debian package. However, as they create nondeterministic contents this makes the package unreproducible.

I originally filed this in Debian as [bug #1041842](https://bugs.debian.org/1041842). The patch is slightly different there as I didn't notice the conditional block until now; this patch should be preferred instead.